### PR TITLE
add name properties from wikidata

### DIFF
--- a/data/112/591/395/1/1125913951.geojson
+++ b/data/112/591/395/1/1125913951.geojson
@@ -34,6 +34,9 @@
     "name:ang_x_preferred":[
         "Calpis"
     ],
+    "name:anp_x_preferred":[
+        "\u091c\u093f\u092c\u094d\u0930\u093e\u0932\u094d\u091f\u0930"
+    ],
     "name:ara_x_preferred":[
         "\u0645\u062d\u0645\u064a\u0629 \u062c\u0628\u0644 \u0637\u0627\u0631\u0642"
     ],
@@ -178,6 +181,9 @@
     "name:glv_x_preferred":[
         "Gibraaltar"
     ],
+    "name:got_x_preferred":[
+        "\ud800\udf46\ud800\udf30\ud800\udf39\ud800\udf42\ud800\udf32\ud800\udf3f\ud800\udf3d\ud800\udf39 \ud800\udf44\ud800\udf30\ud800\udf42\ud800\udf34\ud800\udf39\ud800\udf3a\ud800\udf39\ud800\udf43"
+    ],
     "name:gsw_x_preferred":[
         "Gibraltar"
     ],
@@ -292,6 +298,9 @@
     "name:lit_x_preferred":[
         "Gibraltaras"
     ],
+    "name:lld_x_preferred":[
+        "Gibraltar"
+    ],
     "name:lmo_x_preferred":[
         "Gibiltera"
     ],
@@ -312,6 +321,9 @@
     ],
     "name:mkd_x_preferred":[
         "\u0413\u0438\u0431\u0440\u0430\u043b\u0442\u0430\u0440"
+    ],
+    "name:mlg_x_preferred":[
+        "Gibraltara"
     ],
     "name:mlt_x_preferred":[
         "\u0120ibilt\u00e0"
@@ -400,6 +412,9 @@
     "name:ron_x_preferred":[
         "Gibraltar"
     ],
+    "name:rue_x_preferred":[
+        "\u0414\u0436\u0456\u0431\u0440\u0430\u043b\u0442\u0430\u0440"
+    ],
     "name:rup_x_preferred":[
         "Ghibraltar"
     ],
@@ -412,6 +427,15 @@
     "name:sco_x_preferred":[
         "Gibraltar"
     ],
+    "name:sgs_x_preferred":[
+        "G\u0117braltars"
+    ],
+    "name:shi_x_preferred":[
+        "Djabal \u1e6cariq"
+    ],
+    "name:shn_x_preferred":[
+        "\u1075\u103b\u102e\u1087\u1015\u101b\u1031\u1083\u1038\u1010\u1083\u1038"
+    ],
     "name:sin_x_preferred":[
         "\u0da2\u0dd2\u0db6\u0dca\u200d\u0dbb\u0ddd\u0dbd\u0dca\u0da7\u0dcf\u0dc0"
     ],
@@ -419,6 +443,9 @@
         "Gibralt\u00e1r"
     ],
     "name:slv_x_preferred":[
+        "Gibraltar"
+    ],
+    "name:smn_x_preferred":[
         "Gibraltar"
     ],
     "name:snd_x_preferred":[
@@ -446,6 +473,9 @@
         "Gibraltar"
     ],
     "name:swe_x_preferred":[
+        "Gibraltar"
+    ],
+    "name:szl_x_preferred":[
         "Gibraltar"
     ],
     "name:tam_x_preferred":[
@@ -491,13 +521,17 @@
         "\u06af\u0628\u0631\u0627\u0644\u0679\u0631"
     ],
     "name:urd_x_variant":[
-        "\u062c\u0628\u0644 \u0627\u0644\u0637\u0627\u0631\u0642"
+        "\u062c\u0628\u0644 \u0627\u0644\u0637\u0627\u0631\u0642",
+        "\u062c\u0628\u0631\u0627\u0644\u0679\u0631"
     ],
     "name:uzb_x_preferred":[
         "Gibraltar"
     ],
     "name:vec_x_preferred":[
         "Gibiltera"
+    ],
+    "name:vec_x_variant":[
+        "Zibiltera"
     ],
     "name:vie_x_preferred":[
         "Gibraltar"
@@ -541,6 +575,9 @@
     "name:zho_x_preferred":[
         "\u76f4\u5e03\u7f57\u9640"
     ],
+    "name:zho_x_variant":[
+        "\u76f4\u5e03\u7f85\u9640"
+    ],
     "qs_pg:aaroncc":"GI",
     "qs_pg:gn_country":"GI",
     "qs_pg:gn_fcode":"PPLC",
@@ -578,7 +615,7 @@
         }
     ],
     "wof:id":1125913951,
-    "wof:lastmodified":1636502622,
+    "wof:lastmodified":1690921755,
     "wof:name":"Gibraltar",
     "wof:parent_id":85684619,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.

This PR adds new name:* properties from Wikidata. Existing name properties were also cleaned up to remove duplicate name values when present.

This is one PR in a set of PRs needed to close the linked issue.. once approved, I'll merge. Per-language and updated feature counts are listed in https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.